### PR TITLE
Add missing var when not enabling the service.

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -89,6 +89,8 @@ class puppet::agent(
       }
     }
   } else {
+    $service_notify = Service[$puppet_agent_service]
+
     service { $puppet_agent_service:
       ensure  => stopped,
       enable  => false,


### PR DESCRIPTION
We only trip an issue further down in this manifest when the host is
also a Puppetmaster.  Looks to be a parse order issue around the concat
resources that causes the issue to surface.